### PR TITLE
Include a link to the docs

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -8,6 +8,10 @@
 **NOTE** bindings are currently quite barebones (i.e. only allow opening a library and loading a
 symbol from it) and should get expanded over time.
 
+The documentation can be found [here][docs].
+
+[docs]: http://nagisa.github.io/rust_libloading/libloading/index.html
+
 This library is a safer (compared to the deprecated `dynamic_lib`) binding to platform’s dynamic
 library loading utilities. The most important safety guarantee by this library is prevention of
 dangling-`Symbol`s that may occur after a `Library` is unloaded. Due to several Rust features used


### PR DESCRIPTION
The README includes a link to a subpage of the docs, so it could also use one to the docs main page :).