### PR TITLE
Build winapi crates on Windows only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ documentation = "https://nagisa.github.io/rust_libloading/"
 [dependencies]
 winapi = "0.2"
 kernel32-sys = "0.2"
-lazy_static = "0.1"
+lazy_static = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ repository = "https://github.com/nagisa/rust_libloading/"
 documentation = "https://nagisa.github.io/rust_libloading/"
 
 [dependencies]
+lazy_static = "0.2"
+
+[target.'cfg(windows)'.dependencies]
 winapi = "0.2"
 kernel32-sys = "0.2"
-lazy_static = "0.2"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,10 @@ environment:
   - TARGET: nightly-i686-pc-windows-msvc
   - TARGET: nightly-x86_64-pc-windows-gnu
   - TARGET: nightly-i686-pc-windows-gnu
-  - TARGET: 1.6.0-x86_64-pc-windows-msvc
-  - TARGET: 1.6.0-i686-pc-windows-msvc
-  - TARGET: 1.6.0-x86_64-pc-windows-gnu
-  - TARGET: 1.6.0-i686-pc-windows-gnu
+  - TARGET: 1.8.0-x86_64-pc-windows-msvc
+  - TARGET: 1.8.0-i686-pc-windows-msvc
+  - TARGET: 1.8.0-x86_64-pc-windows-gnu
+  - TARGET: 1.8.0-i686-pc-windows-gnu
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:TARGET}.exe" -FileName "rust.exe"
   - ps: .\rust.exe /VERYSILENT /NORESTART /DIR="C:\rust" | Out-Null


### PR DESCRIPTION
Requires Rust 1.8 or later.