### PR TITLE
Allow symbols to be cloned.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,7 @@ impl fmt::Debug for Library {
 /// let sine0 = unsafe { sin(0f64) };
 /// assert!(sine0 < 0.1E-10);
 /// ```
+#[derive(Clone)]
 pub struct Symbol<'lib, T: 'lib> {
     inner: imp::Symbol<T>,
     pd: marker::PhantomData<&'lib T>

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -168,6 +168,7 @@ impl fmt::Debug for Library {
 ///
 /// A major difference compared to the cross-platform `Symbol` is that this does not ensure the
 /// `Symbol` does not outlive `Library` it comes from.
+#[derive(Clone)]
 pub struct Symbol<T> {
     pointer: *mut raw::c_void,
     pd: marker::PhantomData<T>

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -107,6 +107,7 @@ impl fmt::Debug for Library {
 ///
 /// A major difference compared to the cross-platform `Symbol` is that this does not ensure the
 /// `Symbol` does not outlive `Library` it comes from.
+#[derive(Clone)]
 pub struct Symbol<T> {
     pointer: winapi::FARPROC,
     pd: marker::PhantomData<T>


### PR DESCRIPTION
I have been using your library pretty extensively one of my projects. This project has an event system which allows functions from many dlls to be called at one callsite. Currently, for each event I have to store an Rc or Arc to each Symbol it may call. This means that I have to pay for the ref-count increment/decrement plus the overhead of interlocking for Arc and then I have to dereference each symbol to make the call. My events could simply store the Symbol itself, but the Symbol struct does not provide a clone trait. The derives I added here are sufficient for providing Clone for these structs.