### PR TITLE
Make Library and Symbol implement Sync

### DIFF
--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -187,6 +187,8 @@ pub struct Symbol<T> {
     pd: marker::PhantomData<T>
 }
 
+unsafe impl<T> ::std::marker::Sync for Symbol<T> {}
+
 impl<T> Clone for Symbol<T> {
     fn clone(&self) -> Symbol<T> {
         Symbol { ..*self }

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -53,8 +53,22 @@ pub struct Library {
 }
 
 unsafe impl ::std::marker::Send for Library {}
-// This cannot be Sync, because with RTLD_LAZY dlsym may do relocations, which is not guaranteed to
-// be thread-safe.
+
+// That being said... this section in the volume 2 of POSIX.1-2008 states:
+//
+// > All functions defined by this volume of POSIX.1-2008 shall be thread-safe, except that the
+// > following functions need not be thread-safe.
+//
+// With notable absence of any dl* function other than dlerror in the list. By “this volume”
+// I suppose they refer precisely to the “volume 2”. dl* family of functions are specified
+// by this same volume, so the conclusion is indeed that dl* functions are required by POSIX
+// to be thread-safe. Great!
+//
+// See for more details:
+//
+//  * https://github.com/nagisa/rust_libloading/pull/17
+//  * http://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_09_01
+unsafe impl ::std::marker::Sync for Library {}
 
 impl Library {
     /// Find and load a shared library (module).

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -132,6 +132,8 @@ pub struct Symbol<T> {
     pd: marker::PhantomData<T>
 }
 
+unsafe impl<T> ::std::marker::Sync for Symbol<T> {}
+
 impl<T> Clone for Symbol<T> {
     fn clone(&self) -> Symbol<T> {
         Symbol { ..*self }

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -13,7 +13,8 @@ use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering};
 pub struct Library(winapi::HMODULE);
 
 unsafe impl ::std::marker::Send for Library {}
-// This probably could implement Sync. At least I found no reason not to so far.
+
+unsafe impl ::std::marker::Sync for Library {}
 
 impl Library {
     /// Find and load a shared library (module).

--- a/tests/send.rs
+++ b/tests/send.rs
@@ -1,12 +1,9 @@
 extern crate libloading;
 
-use libloading::Symbol;
+use libloading::{Library, Symbol};
 
-#[cfg(unix)]
 #[test]
 fn check_library_sync() {
-	use libloading::Library;
-
     fn send<S: Sync>(_: Option<S>) {}
     send::<Library>(None);
 }

--- a/tests/send.rs
+++ b/tests/send.rs
@@ -1,0 +1,9 @@
+extern crate libloading;
+
+use libloading::Symbol;
+
+#[test]
+fn check_symbol_sync() {
+    fn send<S: Sync>(_: Option<S>) {}
+    send::<Symbol<fn ()>>(None);
+}

--- a/tests/send.rs
+++ b/tests/send.rs
@@ -2,6 +2,15 @@ extern crate libloading;
 
 use libloading::Symbol;
 
+#[cfg(unix)]
+#[test]
+fn check_library_sync() {
+	use libloading::Library;
+
+    fn send<S: Sync>(_: Option<S>) {}
+    send::<Library>(None);
+}
+
 #[test]
 fn check_symbol_sync() {
     fn send<S: Sync>(_: Option<S>) {}


### PR DESCRIPTION
I added Sync marker to Library and Symbol. Also I added test for Sync marker present.

 * I don't see any contras for Sync on Symbol (it simply reference to **unsafe** function).
 * On Windows I don't see any contras for Sync on Library (looks like `LoadLibrary`/`GetProcAddress`/`FreeLibrary` are thread safe, but I can't find any proof link);
 * On Linux `dlsym` should be thread safe (http://man7.org/linux/man-pages/man3/dlopen.3.html).

About `dlsym` thread safity:

 * Looks like `dlsym` should be thread safe: http://man7.org/linux/man-pages/man3/dlopen.3.html (and there are no RTLD_LAZY remarks here);
 * I found bug: https://bugzilla.redhat.com/show_bug.cgi?id=85270 (it was fixed ~13 years ago);
 * If `dlsym` is not thread safe, then IMHO it can be used only from one thread and without `Sync` it would not be safe (I can simply create many `Library` objects from differ threads and crash).
