### PR TITLE
Set `default-features` to false for target_build_utils.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ lazy_static = "0.2"
 winapi = "0.2"
 kernel32-sys = "0.2"
 
-[build-dependencies]
-target_build_utils = "0.3"
+[build-dependencies.target_build_utils]
+version = "0.3"
+default-features = false


### PR DESCRIPTION
This change is related to https://github.com/servo/rust-bindgen/issues/499

I believe that this is the best way to remove the json dependency from this project as it does not appear to use that feature of `target_build_utils`.