### PR TITLE
Update to winapi 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ documentation = "https://docs.rs/libloading/"
 [dependencies]
 lazy_static = "1"
 
-[target.'cfg(windows)'.dependencies]
-winapi = "0.2"
-kernel32-sys = "0.2"
+[target.'cfg(windows)'.dependencies.winapi]
+version = "0.3"
+features = [
+    "winerror",
+    "errhandlingapi",
+    "libloaderapi",
+]

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -1,5 +1,8 @@
 extern crate winapi;
-extern crate kernel32;
+use self::winapi::shared::minwindef::{WORD, DWORD, HMODULE, FARPROC};
+use self::winapi::shared::ntdef::WCHAR;
+use self::winapi::shared::winerror;
+use self::winapi::um::{errhandlingapi, libloaderapi};
 
 use util::{ensure_compatible_types, cstr_cow_from_bytes};
 
@@ -10,7 +13,7 @@ use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering};
 
 
 /// A platform-specific equivalent of the cross-platform `Library`.
-pub struct Library(winapi::HMODULE);
+pub struct Library(HMODULE);
 
 unsafe impl Send for Library {}
 // Now, this is sort-of-tricky. MSDN documentation does not really make any claims as to safety of
@@ -40,7 +43,7 @@ impl Library {
         let ret = with_get_last_error(|| {
             // Make sure no winapi calls as a result of drop happen inside this closure, because
             // otherwise that might change the return value of the GetLastError.
-            let handle = unsafe { kernel32::LoadLibraryW(wide_filename.as_ptr()) };
+            let handle = unsafe { libloaderapi::LoadLibraryW(wide_filename.as_ptr()) };
             if handle.is_null()  {
                 None
             } else {
@@ -68,10 +71,10 @@ impl Library {
     /// Pointer to a value of arbitrary type is returned. Using a value with wrong type is
     /// undefined.
     pub unsafe fn get<T>(&self, symbol: &[u8]) -> ::Result<Symbol<T>> {
-        ensure_compatible_types::<T, winapi::FARPROC>();
+        ensure_compatible_types::<T, FARPROC>();
         let symbol = try!(cstr_cow_from_bytes(symbol));
         with_get_last_error(|| {
-            let symbol = kernel32::GetProcAddress(self.0, symbol.as_ptr());
+            let symbol = libloaderapi::GetProcAddress(self.0, symbol.as_ptr());
             if symbol.is_null() {
                 None
             } else {
@@ -91,11 +94,11 @@ impl Library {
     ///
     /// Pointer to a value of arbitrary type is returned. Using a value with wrong type is
     /// undefined.
-    pub unsafe fn get_ordinal<T>(&self, ordinal: winapi::WORD) -> ::Result<Symbol<T>> {
-        ensure_compatible_types::<T, winapi::FARPROC>();
+    pub unsafe fn get_ordinal<T>(&self, ordinal: WORD) -> ::Result<Symbol<T>> {
+        ensure_compatible_types::<T, FARPROC>();
         with_get_last_error(|| {
             let ordinal = ordinal as usize as *mut _;
-            let symbol = kernel32::GetProcAddress(self.0, ordinal);
+            let symbol = libloaderapi::GetProcAddress(self.0, ordinal);
             if symbol.is_null() {
                 None
             } else {
@@ -113,7 +116,7 @@ impl Library {
 impl Drop for Library {
     fn drop(&mut self) {
         with_get_last_error(|| {
-            if unsafe { kernel32::FreeLibrary(self.0) == 0 } {
+            if unsafe { libloaderapi::FreeLibrary(self.0) == 0 } {
                 None
             } else {
                 Some(())
@@ -125,8 +128,8 @@ impl Drop for Library {
 impl fmt::Debug for Library {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         unsafe {
-            let mut buf: [winapi::WCHAR; 1024] = mem::uninitialized();
-            let len = kernel32::GetModuleFileNameW(self.0,
+            let mut buf: [WCHAR; 1024] = mem::uninitialized();
+            let len = libloaderapi::GetModuleFileNameW(self.0,
                                                    (&mut buf[..]).as_mut_ptr(), 1024) as usize;
             if len == 0 {
                 f.write_str(&format!("Library@{:p}", self.0))
@@ -143,7 +146,7 @@ impl fmt::Debug for Library {
 /// A major difference compared to the cross-platform `Symbol` is that this does not ensure the
 /// `Symbol` does not outlive `Library` it comes from.
 pub struct Symbol<T> {
-    pointer: winapi::FARPROC,
+    pointer: FARPROC,
     pd: marker::PhantomData<T>
 }
 
@@ -188,16 +191,16 @@ impl<T> fmt::Debug for Symbol<T> {
 
 
 static USE_ERRORMODE: AtomicBool = ATOMIC_BOOL_INIT;
-struct ErrorModeGuard(winapi::DWORD);
+struct ErrorModeGuard(DWORD);
 
 impl ErrorModeGuard {
     fn new() -> Option<ErrorModeGuard> {
-        const SEM_FAILCE: winapi::DWORD = 1;
+        const SEM_FAILCE: DWORD = 1;
         unsafe {
             if !USE_ERRORMODE.load(Ordering::Acquire) {
                 let mut previous_mode = 0;
-                let success = kernel32::SetThreadErrorMode(SEM_FAILCE, &mut previous_mode) != 0;
-                if !success && kernel32::GetLastError() == winapi::ERROR_CALL_NOT_IMPLEMENTED {
+                let success = errhandlingapi::SetThreadErrorMode(SEM_FAILCE, &mut previous_mode) != 0;
+                if !success && errhandlingapi::GetLastError() == winerror::ERROR_CALL_NOT_IMPLEMENTED {
                     USE_ERRORMODE.store(true, Ordering::Release);
                 } else if !success {
                     // SetThreadErrorMode failed with some other error? How in the world is it
@@ -212,7 +215,7 @@ impl ErrorModeGuard {
                     return Some(ErrorModeGuard(previous_mode));
                 }
             }
-            match kernel32::SetErrorMode(SEM_FAILCE) {
+            match errhandlingapi::SetErrorMode(SEM_FAILCE) {
                 SEM_FAILCE => {
                     // This is important to reduce racy-ness when this library is used on multiple
                     // threads. In particular this helps with following race condition:
@@ -239,9 +242,9 @@ impl Drop for ErrorModeGuard {
     fn drop(&mut self) {
         unsafe {
             if !USE_ERRORMODE.load(Ordering::Relaxed) {
-                kernel32::SetThreadErrorMode(self.0, ptr::null_mut());
+                errhandlingapi::SetThreadErrorMode(self.0, ptr::null_mut());
             } else {
-                kernel32::SetErrorMode(self.0);
+                errhandlingapi::SetErrorMode(self.0);
             }
         }
     }
@@ -250,7 +253,7 @@ impl Drop for ErrorModeGuard {
 fn with_get_last_error<T, F>(closure: F) -> Result<T, Option<io::Error>>
 where F: FnOnce() -> Option<T> {
     closure().ok_or_else(|| {
-        let error = unsafe { kernel32::GetLastError() };
+        let error = unsafe { errhandlingapi::GetLastError() };
         if error == 0 {
             None
         } else {
@@ -262,23 +265,23 @@ where F: FnOnce() -> Option<T> {
 #[test]
 fn works_getlasterror() {
     let lib = Library::new("kernel32.dll").unwrap();
-    let gle: Symbol<unsafe extern "system" fn() -> winapi::DWORD> = unsafe {
+    let gle: Symbol<unsafe extern "system" fn() -> DWORD> = unsafe {
         lib.get(b"GetLastError").unwrap()
     };
     unsafe {
-        kernel32::SetLastError(42);
-        assert_eq!(kernel32::GetLastError(), gle())
+        errhandlingapi::SetLastError(42);
+        assert_eq!(errhandlingapi::GetLastError(), gle())
     }
 }
 
 #[test]
 fn works_getlasterror0() {
     let lib = Library::new("kernel32.dll").unwrap();
-    let gle: Symbol<unsafe extern "system" fn() -> winapi::DWORD> = unsafe {
+    let gle: Symbol<unsafe extern "system" fn() -> DWORD> = unsafe {
         lib.get(b"GetLastError\0").unwrap()
     };
     unsafe {
-        kernel32::SetLastError(42);
-        assert_eq!(kernel32::GetLastError(), gle())
+        errhandlingapi::SetLastError(42);
+        assert_eq!(errhandlingapi::GetLastError(), gle())
     }
 }


### PR DESCRIPTION
This pull request updated `libloading` to `winapi` 0.3.

This greatly improves compilation time on Windows since it only enables the required features. On my machine, a clean build went from 20 seconds with the old version to 3 seconds with the new version.