### PR TITLE
Add support for building on Haiku.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,7 @@ fn main(){
         // What happens if the executable is not linked up dynamically?
         Ok("openbsd") | Ok("bitrig") | Ok("netbsd") | Ok("macos") | Ok("ios") => {}
         Ok("solaris") => {}
+        Ok("haiku") => {}
         // dependencies come with winapi
         Ok("windows") => {}
         tos => {


### PR DESCRIPTION
This pull request allows libloading to recognise and compile successfully on Haiku. Tested on x86_64-unknown-haiku and passes all [tests](https://gist.github.com/return/160c298ca1e2a68a0378cd4a69b36a86).