### PR TITLE
Modernise the codebase slightly

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,5 +1,10 @@
 //! Project changelog
 
+/// Release NEXT (2020-04-??)
+///
+/// * Minimum version requirement for the compiler is now 1.36.0.
+pub mod rNEXT {}
+
 /// Release 0.5.2 (2019-07-07)
 ///
 /// * Added API to convert OS-specific `Library` and `Symbol` conversion to underlying resources.

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -124,7 +124,7 @@ impl Library {
     where P: AsRef<OsStr> {
         let filename = match filename {
             None => None,
-            Some(ref f) => Some(try!(cstr_cow_from_bytes(f.as_ref().as_bytes()))),
+            Some(ref f) => Some(cstr_cow_from_bytes(f.as_ref().as_bytes())?),
         };
         with_dlerror(move || {
             let result = unsafe {
@@ -167,7 +167,7 @@ impl Library {
     /// impossible. Using a TLS variable loaded this way on OS X is undefined behaviour.
     pub unsafe fn get<T>(&self, symbol: &[u8]) -> ::Result<Symbol<T>> {
         ensure_compatible_types::<T, *mut raw::c_void>();
-        let symbol = try!(cstr_cow_from_bytes(symbol));
+        let symbol = cstr_cow_from_bytes(symbol)?;
         // `dlsym` may return nullptr in two cases: when a symbol genuinely points to a null
         // pointer or the symbol cannot be found. In order to detect this case a double dlerror
         // pattern must be used, which is, sadly, a little bit racy.
@@ -289,8 +289,9 @@ impl<T> ::std::ops::Deref for Symbol<T> {
 impl<T> fmt::Debug for Symbol<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         unsafe {
-            let mut info: DlInfo = mem::uninitialized();
-            if dladdr(self.pointer, &mut info) != 0 {
+            let mut info = mem::MaybeUninit::<DlInfo>::uninit();
+            if dladdr(self.pointer, info.as_mut_ptr()) != 0 {
+                let info = info.assume_init();
                 if info.dli_sname.is_null() {
                     f.write_str(&format!("Symbol@{:p} from {:?}",
                                          self.pointer,

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -72,7 +72,7 @@ impl Library {
     /// undefined.
     pub unsafe fn get<T>(&self, symbol: &[u8]) -> ::Result<Symbol<T>> {
         ensure_compatible_types::<T, FARPROC>();
-        let symbol = try!(cstr_cow_from_bytes(symbol));
+        let symbol = cstr_cow_from_bytes(symbol)?;
         with_get_last_error(|| {
             let symbol = libloaderapi::GetProcAddress(self.0, symbol.as_ptr());
             if symbol.is_null() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -42,9 +42,9 @@ pub fn cstr_cow_from_bytes<'a>(slice: &'a [u8]) -> Result<Cow<'a, CStr>, NullErr
         // Slice out of 0 elements
         None => unsafe { Cow::Borrowed(CStr::from_ptr(&ZERO)) },
         // Slice with trailing 0
-        Some(&0) => Cow::Borrowed(try!(CStr::from_bytes_with_nul(slice))),
+        Some(&0) => Cow::Borrowed(CStr::from_bytes_with_nul(slice)?),
         // Slice with no trailing 0
-        Some(_) => Cow::Owned(try!(CString::new(slice))),
+        Some(_) => Cow::Owned(CString::new(slice)?),
     })
 }
 

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -4,7 +4,7 @@ use libloading::{Symbol, Library};
 const LIBPATH: &'static str = concat!(env!("OUT_DIR"), "/libtest_helpers.dll");
 
 fn make_helpers() {
-    static ONCE: ::std::sync::Once = ::std::sync::ONCE_INIT;
+    static ONCE: ::std::sync::Once = ::std::sync::Once::new();
     ONCE.call_once(|| {
         let mut outpath = String::from(if let Some(od) = option_env!("OUT_DIR") { od } else { return });
         let rustc = option_env!("RUSTC").unwrap_or_else(|| { "rustc".into() });


### PR DESCRIPTION
This removes use of all the deprecated features in current versions of rustc.