### PR TITLE
feat: add name resolving library open function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,6 @@ impl Library {
     /// OS during runtime.
     pub fn with_name_resolve<T: AsRef<str>>(libname: T) -> Result<Library, Error> {
         let resolved_name = Self::resolve_name(libname.as_ref());
-        println!("resolved: {}", &resolved_name);
         Self::new(resolved_name.deref())
     }
 


### PR DESCRIPTION
The newly added method does resolve the library name passed to it by
adhering to platform-specific naming schemes using Rust provided
constants.

Closes #62