### PR TITLE
Don't neglect to forget `self` in `close`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,8 @@ impl Library {
     /// You only need to call this if you are interested in handling any errors that may arise when
     /// library is unloaded. Otherwise the implementation of `Drop` for `Library` will close the
     /// library and ignore the errors were they arise.
+    ///
+    /// The underlying data structures may still get leaked if an error does occur.
     pub fn close(self) -> Result<(), Error> {
         self.0.close()
     }


### PR DESCRIPTION
Otherwise it leads to a double-free, once in `close` and another time in
`drop`. Curiously this was only a bug on Windows, and Unix code was
fine. Not sure how this happened.

Fixes #82 