### PR TITLE
Made the documentation more idiomatic and fixed some small grammatical errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "ISC"
 repository = "https://github.com/nagisa/rust_libloading/"
 documentation = "https://docs.rs/libloading/"
 readme = "README.mkd"
-description = "A safer binding to platform’s dynamic library loading utilities"
+description = "Bindings around the platform's dynamic library loading primitives with greatly improved memory safety."
 keywords = ["dlopen", "load", "shared", "dylib"]
 categories = ["api-bindings"]
 

--- a/README.mkd
+++ b/README.mkd
@@ -1,11 +1,8 @@
 # libloading
 
-Safer bindings around system dynamic library loading primitives. The most important safety
-guarantee by this library is prevention of dangling-`Symbol`s that may occur after a `Library` is
-unloaded.
+Bindings around the platform's dynamic library loading primitives with greatly improved memory safety. The most important safety guarantee of this library is the prevention of dangling `Symbol`s that may occur after a `Library` is unloaded.
 
-Using this library allows loading dynamic libraries (also known as shared libraries) as well as use
-functions and static variables these libraries contain.
+Using this library allows the loading of dynamic libraries, also known as shared libraries, as well as the use of the functions and static variables that these libraries may contain.
 
 * [Documentation][docs]
 * [Changelog][changelog]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,8 +136,7 @@ impl Library {
     ///
     /// # Safety
     ///
-    /// Users of this API must specify the correct type of the function or variable loaded. Using a
-    /// `Symbol` with a wrong type causes undefined behaviour.
+    /// Users of this API must specify the correct type of the function or variable loaded.
     ///
     /// # Platform-specific behaviour
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ impl Library {
 
     /// Get a pointer to a function or static variable by symbol name.
     ///
-    /// The `symbol` may not contain any null bytes, with an exception of last byte. Providing a
+    /// The `symbol` may not contain any null bytes, with the exception of the last byte. Providing a
     /// null-terminated `symbol` may help to avoid an allocation.
     ///
     /// The symbol is interpreted as-is; no mangling is done. This means that symbols like `x::y` are

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -1,6 +1,6 @@
-//! Unsafe but flexible platform specific bindings to dynamic library loading facilities.
+//! Unsafe but flexible platform-specific bindings to dynamic library loading facilities.
 //!
-//! These modules expose more extensive, powerful, less principled bindings to the dynamic
+//! These modules expose more extensive and powerful bindings to the dynamic
 //! library loading facilities. Use of these bindings come at the cost of less (in most cases,
 //! none at all) safety guarantees, which are provided by the top-level bindings.
 //!

--- a/src/os/unix/consts.rs
+++ b/src/os/unix/consts.rs
@@ -7,7 +7,7 @@ use std::os::raw::c_int;
 /// Specifying `RTLD_LAZY` should improve performance on implementations supporting dynamic
 /// symbol binding since a process might not reference all of the symbols in an executable
 /// object file. And, for systems supporting dynamic symbol resolution for normal process
-/// execution, this behavior mimics the normal handling of process execution.
+/// execution, this behaviour mimics the normal handling of process execution.
 ///
 /// Conflicts with [`RTLD_NOW`].
 ///
@@ -18,7 +18,7 @@ pub const RTLD_LAZY: c_int = posix::RTLD_LAZY;
 ///
 /// All necessary relocations shall be performed when the executable object file is first
 /// loaded. This may waste some processing if relocations are performed for symbols
-/// that are never referenced. This behavior may be useful for applications that need to
+/// that are never referenced. This behaviour may be useful for applications that need to
 /// know that all symbols referenced during execution will be available before
 /// [`Library::open`] returns.
 ///

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -273,8 +273,7 @@ impl Library {
     ///
     /// # Safety
     ///
-    /// Users of this API must specify the correct type of the function or variable loaded. Using a
-    /// `Symbol` with a wrong type causes undefined behaviour.
+    /// Users of this API must specify the correct type of the function or variable loaded.
     ///
     /// It is up to the user of this library to ensure that no other calls to an MT-unsafe
     /// implementation of `dlerror` occur during the execution of this function. Failing that, the

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -109,7 +109,7 @@ impl Library {
     ///
     /// # Safety
     ///
-    /// When a library is loaded initialisation routines contained within the library are executed.
+    /// When a library is loaded, initialisation routines contained within the library are executed.
     /// For the purposes of safety, the execution of these routines is conceptually the same calling an
     /// unknown foreign function and may impose arbitrary requirements on the caller for the call
     /// to be sound.
@@ -156,7 +156,7 @@ impl Library {
     ///
     /// # Safety
     ///
-    /// When a library is loaded initialisation routines contained within the library are executed.
+    /// When a library is loaded, initialisation routines contained within the library are executed.
     /// For the purposes of safety, the execution of these routines is conceptually the same calling an
     /// unknown foreign function and may impose arbitrary requirements on the caller for the call
     /// to be sound.

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -142,7 +142,7 @@ impl Library {
     pub fn this() -> Library {
         unsafe {
             // SAFE: this does not load any new shared library images, no danger in it executing
-            // initializer routines.
+            // initialiser routines.
             Library::open(None::<&OsStr>, RTLD_LAZY | RTLD_LOCAL).expect("this should never fail")
         }
     }

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -109,8 +109,8 @@ impl Library {
     ///
     /// # Safety
     ///
-    /// When a library is loaded initialization routines contained within the library are executed.
-    /// For the purposes of safety, execution of these routines is conceptually the same calling an
+    /// When a library is loaded initialisation routines contained within the library are executed.
+    /// For the purposes of safety, the execution of these routines is conceptually the same calling an
     /// unknown foreign function and may impose arbitrary requirements on the caller for the call
     /// to be sound.
     ///
@@ -127,12 +127,12 @@ impl Library {
     /// [`Library::get`] calls of the returned `Library` will look for symbols in following
     /// locations in order:
     ///
-    /// 1. Original program image;
+    /// 1. The original program image;
     /// 2. Any executable object files (e.g. shared libraries) loaded at program startup;
-    /// 3. Executable object files loaded at runtime (e.g. via other `Library::new` calls or via
-    ///    calls to the `dlopen` function)
+    /// 3. Any executable object files loaded at runtime (e.g. via other `Library::new` calls or via
+    ///    calls to the `dlopen` function).
     ///
-    /// Note that behaviour of `Library` loaded with this method is different from
+    /// Note that the behaviour of a `Library` loaded with this method is different from that of
     /// Libraries loaded with [`os::windows::Library::this`].
     ///
     /// This is equivalent to <code>[Library::open](None, [RTLD_LAZY] | [RTLD_LOCAL])</code>.
@@ -149,15 +149,15 @@ impl Library {
 
     /// Find and load an executable object file (shared library).
     ///
-    /// See documentation for [`Library::this`] for further description of behaviour
+    /// See documentation for [`Library::this`] for further description of the behaviour
     /// when the `filename` is `None`. Otherwise see [`Library::new`].
     ///
     /// Corresponds to `dlopen(filename, flags)`.
     ///
     /// # Safety
     ///
-    /// When a library is loaded initialization routines contained within the library are executed.
-    /// For the purposes of safety, execution of these routines is conceptually the same calling an
+    /// When a library is loaded initialisation routines contained within the library are executed.
+    /// For the purposes of safety, the execution of these routines is conceptually the same calling an
     /// unknown foreign function and may impose arbitrary requirements on the caller for the call
     /// to be sound.
     ///
@@ -217,9 +217,9 @@ impl Library {
 
     }
 
-    /// Get a pointer to function or static variable by symbol name.
+    /// Get a pointer to a function or static variable by symbol name.
     ///
-    /// The `symbol` may not contain any null bytes, with an exception of last byte. Providing a
+    /// The `symbol` may not contain any null bytes, with the exception of the last byte. Providing a
     /// null terminated `symbol` may help to avoid an allocation.
     ///
     /// Symbol is interpreted as-is; no mangling is done. This means that symbols like `x::y` are
@@ -265,7 +265,7 @@ impl Library {
 
     /// Get a pointer to function or static variable by symbol name.
     ///
-    /// The `symbol` may not contain any null bytes, with an exception of last byte. Providing a
+    /// The `symbol` may not contain any null bytes, with the exception of the last byte. Providing a
     /// null terminated `symbol` may help to avoid an allocation.
     ///
     /// Symbol is interpreted as-is; no mangling is done. This means that symbols like `x::y` are
@@ -274,15 +274,15 @@ impl Library {
     /// # Safety
     ///
     /// Users of this API must specify the correct type of the function or variable loaded. Using a
-    /// `Symbol` with a wrong type is undefined.
+    /// `Symbol` with a wrong type causes undefined behaviour.
     ///
     /// It is up to the user of this library to ensure that no other calls to an MT-unsafe
-    /// implementation of `dlerror` occur during execution of this function. Failing that, the
+    /// implementation of `dlerror` occur during the execution of this function. Failing that, the
     /// behaviour of this function is not defined.
     ///
     /// # Platform-specific behaviour
     ///
-    /// Implementation of thread local variables is extremely platform specific and uses of such
+    /// The implementation of thread-local variables is extremely platform specific and uses of such
     /// variables that work on e.g. Linux may have unintended behaviour on other targets.
     #[inline(always)]
     pub unsafe fn get_singlethreaded<T>(&self, symbol: &[u8]) -> Result<Symbol<T>, crate::Error> {
@@ -357,15 +357,15 @@ impl fmt::Debug for Library {
 
 /// Symbol from a library.
 ///
-/// A major difference compared to the cross-platform `Symbol` is that this does not ensure the
-/// `Symbol` does not outlive `Library` it comes from.
+/// A major difference compared to the cross-platform `Symbol` is that this does not ensure that the
+/// `Symbol` does not outlive the `Library` it comes from.
 pub struct Symbol<T> {
     pointer: *mut raw::c_void,
     pd: marker::PhantomData<T>
 }
 
 impl<T> Symbol<T> {
-    /// Convert the loaded Symbol into a raw pointer.
+    /// Convert the loaded `Symbol` into a raw pointer.
     pub fn into_raw(self) -> *mut raw::c_void {
         let pointer = self.pointer;
         mem::forget(self);

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -216,8 +216,7 @@ impl Library {
     ///
     /// # Safety
     ///
-    /// Users of this API must specify the correct type of the function or variable loaded. Using a
-    /// `Symbol` with a wrong type causes undefined behaviour.
+    /// Users of this API must specify the correct type of the function or variable loaded.
     pub unsafe fn get<T>(&self, symbol: &[u8]) -> Result<Symbol<T>, crate::Error> {
         ensure_compatible_types::<T, FARPROC>()?;
         let symbol = cstr_cow_from_bytes(symbol)?;
@@ -238,8 +237,7 @@ impl Library {
     ///
     /// # Safety
     ///
-    /// Users of this API must specify the correct type of the function or variable loaded. Using a
-    /// `Symbol` with a wrong type causes undefined behaviour.
+    /// Users of this API must specify the correct type of the function or variable loaded.
     pub unsafe fn get_ordinal<T>(&self, ordinal: WORD) -> Result<Symbol<T>, crate::Error> {
         ensure_compatible_types::<T, FARPROC>()?;
         with_get_last_error(|source| crate::Error::GetProcAddress { source }, || {

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -55,23 +55,23 @@ use util::{ensure_compatible_types, cstr_cow_from_bytes};
 use std::ffi::{OsStr, OsString};
 use std::{fmt, io, marker, mem, ptr};
 
-/// A platform-specific counterpart of the cross-platform [`Library`](crate::Library).
+/// The platform-specific counterpart of the cross-platform [`Library`](crate::Library).
 pub struct Library(HMODULE);
 
 unsafe impl Send for Library {}
 // Now, this is sort-of-tricky. MSDN documentation does not really make any claims as to safety of
 // the Win32 APIs. Sadly, whomever I asked, even current and former Microsoft employees, couldn’t
-// say for sure, whether the Win32 APIs used to implement `Library` are thread-safe or not.
+// say for sure whether the Win32 APIs used to implement `Library` are thread-safe or not.
 //
 // My investigation ended up with a question about thread-safety properties of the API involved
 // being sent to an internal (to MS) general question mailing-list. The conclusion of the mail is
 // as such:
 //
-// * Nobody inside MS (at least out of all the people who have seen the question) knows for
+// * Nobody inside MS (at least out of all of the people who have seen the question) knows for
 //   sure either;
 // * However, the general consensus between MS developers is that one can rely on the API being
 //   thread-safe. In case it is not thread-safe it should be considered a bug on the Windows
-//   part. (NB: bugs filled at https://connect.microsoft.com/ against Windows Server)
+//   part. (NB: bugs filed at https://connect.microsoft.com/ against Windows Server)
 unsafe impl Sync for Library {}
 
 impl Library {
@@ -79,11 +79,11 @@ impl Library {
     ///
     /// If the `filename` specifies a full path, the function only searches that path for the
     /// module. Otherwise, if the `filename` specifies a relative path or a module name without a
-    /// path, the function uses a windows-specific search strategy to find the module; for more
+    /// path, the function uses a Windows-specific search strategy to find the module. For more
     /// information, see the [Remarks on MSDN][msdn].
     ///
-    /// If the `filename` specifies a library filename without path and with extension omitted,
-    /// `.dll` extension is implicitly added. This behaviour may be suppressed by appending a
+    /// If the `filename` specifies a library filename without a path and with the extension omitted,
+    /// the `.dll` extension is implicitly added. This behaviour may be suppressed by appending a
     /// trailing `.` to the `filename`.
     ///
     /// This is equivalent to <code>[Library::load_with_flags](filename, 0)</code>.
@@ -92,8 +92,8 @@ impl Library {
     ///
     /// # Safety
     ///
-    /// When a library is loaded initialization routines contained within the library are executed.
-    /// For the purposes of safety, execution of these routines is conceptually the same calling an
+    /// When a library is loaded initialisation routines contained within the library are executed.
+    /// For the purposes of safety, the execution of these routines is conceptually the same calling an
     /// unknown foreign function and may impose arbitrary requirements on the caller for the call
     /// to be sound.
     ///
@@ -107,7 +107,7 @@ impl Library {
 
     /// Get the `Library` representing the original program executable.
     ///
-    /// Note that behaviour of `Library` loaded with this method is different from
+    /// Note that the behaviour of the `Library` loaded with this method is different from
     /// Libraries loaded with [`os::unix::Library::this`]. For more information refer to [MSDN].
     ///
     /// Corresponds to `GetModuleHandleExW(0, NULL, _)`.
@@ -131,15 +131,15 @@ impl Library {
     /// Get a module that is already loaded by the program.
     ///
     /// This function returns a `Library` corresponding to a module with the given name that is
-    /// already mapped into the address space of the process. If the module isn't found an error is
+    /// already mapped into the address space of the process. If the module isn't found, an error is
     /// returned.
     ///
     /// If the `filename` does not include a full path and there are multiple different loaded
     /// modules corresponding to the `filename`, it is impossible to predict which module handle
     /// will be returned. For more information refer to [MSDN].
     ///
-    /// If the `filename` specifies a library filename without path and with extension omitted,
-    /// `.dll` extension is implicitly added. This behaviour may be suppressed by appending a
+    /// If the `filename` specifies a library filename without a path and with the extension omitted,
+    /// the `.dll` extension is implicitly added. This behaviour may be suppressed by appending a
     /// trailing `.` to the `filename`.
     ///
     /// This is equivalent to `GetModuleHandleExW(0, filename, _)`.
@@ -169,7 +169,7 @@ impl Library {
 
     /// Find and load a module, additionally adjusting behaviour with flags.
     ///
-    /// See [`Library::new`] for documentation on handling of the `filename` argument. See the
+    /// See [`Library::new`] for documentation on the handling of the `filename` argument. See the
     /// [flag table on MSDN][flags] for information on applicable values for the `flags` argument.
     ///
     /// Corresponds to `LoadLibraryExW(filename, reserved: NULL, flags)`.
@@ -178,8 +178,8 @@ impl Library {
     ///
     /// # Safety
     ///
-    /// When a library is loaded initialization routines contained within the library are executed.
-    /// For the purposes of safety, execution of these routines is conceptually the same calling an
+    /// When a library is loaded initialisation routines contained within the library are executed.
+    /// For the purposes of safety, the execution of these routines is conceptually the same calling an
     /// unknown foreign function and may impose arbitrary requirements on the caller for the call
     /// to be sound.
     ///
@@ -206,9 +206,9 @@ impl Library {
         ret
     }
 
-    /// Get a pointer to function or static variable by symbol name.
+    /// Get a pointer to a function or static variable by symbol name.
     ///
-    /// The `symbol` may not contain any null bytes, with an exception of last byte. A null
+    /// The `symbol` may not contain any null bytes, with the exception of the last byte. A null
     /// terminated `symbol` may avoid a string allocation in some cases.
     ///
     /// Symbol is interpreted as-is; no mangling is done. This means that symbols like `x::y` are
@@ -217,7 +217,7 @@ impl Library {
     /// # Safety
     ///
     /// Users of this API must specify the correct type of the function or variable loaded. Using a
-    /// `Symbol` with a wrong type is undefined.
+    /// `Symbol` with a wrong type causes undefined behaviour.
     pub unsafe fn get<T>(&self, symbol: &[u8]) -> Result<Symbol<T>, crate::Error> {
         ensure_compatible_types::<T, FARPROC>()?;
         let symbol = cstr_cow_from_bytes(symbol)?;
@@ -234,12 +234,12 @@ impl Library {
         }).map_err(|e| e.unwrap_or(crate::Error::GetProcAddressUnknown))
     }
 
-    /// Get a pointer to function or static variable by ordinal number.
+    /// Get a pointer to a function or static variable by ordinal number.
     ///
     /// # Safety
     ///
     /// Users of this API must specify the correct type of the function or variable loaded. Using a
-    /// `Symbol` with a wrong type is undefined.
+    /// `Symbol` with a wrong type causes undefined behaviour.
     pub unsafe fn get_ordinal<T>(&self, ordinal: WORD) -> Result<Symbol<T>, crate::Error> {
         ensure_compatible_types::<T, FARPROC>()?;
         with_get_last_error(|source| crate::Error::GetProcAddress { source }, || {
@@ -267,8 +267,8 @@ impl Library {
     ///
     /// # Safety
     ///
-    /// The handle shall be a result of a successful call of `LoadLibraryA`, `LoadLibraryW`,
-    /// `LoadLibraryExW`, `LoadLibraryExA` or a handle previously returned by the
+    /// The handle must be the result of a successful call of `LoadLibraryA`, `LoadLibraryW`,
+    /// `LoadLibraryExW`, or `LoadLibraryExA`, or a handle previously returned by the
     /// `Library::into_raw` call.
     pub unsafe fn from_raw(handle: HMODULE) -> Library {
         Library(handle)
@@ -290,7 +290,7 @@ impl Library {
         }).map_err(|e| e.unwrap_or(crate::Error::FreeLibraryUnknown));
         // While the library is not free'd yet in case of an error, there is no reason to try
         // dropping it again, because all that will do is try calling `FreeLibrary` again. only
-        // this time it would ignore the return result, which we already seen failing…
+        // this time it would ignore the return result, which we already seen failing...
         std::mem::forget(self);
         result
     }
@@ -323,17 +323,17 @@ impl fmt::Debug for Library {
     }
 }
 
-/// Symbol from a library.
+/// A symbol from a library.
 ///
-/// A major difference compared to the cross-platform `Symbol` is that this does not ensure the
-/// `Symbol` does not outlive `Library` it comes from.
+/// A major difference compared to the cross-platform `Symbol` is that this does not ensure that the
+/// `Symbol` does not outlive the `Library` that it comes from.
 pub struct Symbol<T> {
     pointer: FARPROC,
     pd: marker::PhantomData<T>
 }
 
 impl<T> Symbol<T> {
-    /// Convert the loaded Symbol into a handle.
+    /// Convert the loaded `Symbol` into a handle.
     pub fn into_raw(self) -> FARPROC {
         let pointer = self.pointer;
         mem::forget(self);
@@ -462,7 +462,7 @@ pub const LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE: DWORD = consts::LOAD_LIBRARY_AS_DA
 /// See [flag documentation on MSDN](https://docs.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw#parameters).
 pub const LOAD_LIBRARY_AS_IMAGE_RESOURCE: DWORD = consts::LOAD_LIBRARY_AS_IMAGE_RESOURCE;
 
-/// Search application's installation directory for the DLL and its dependencies.
+/// Search the application's installation directory for the DLL and its dependencies.
 ///
 /// Directories in the standard search path are not searched. This value cannot be combined with
 /// [`LOAD_WITH_ALTERED_SEARCH_PATH`].
@@ -509,7 +509,7 @@ pub const LOAD_LIBRARY_SEARCH_SYSTEM32: DWORD = consts::LOAD_LIBRARY_SEARCH_SYST
 /// See [flag documentation on MSDN](https://docs.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw#parameters).
 pub const LOAD_LIBRARY_SEARCH_USER_DIRS: DWORD = consts::LOAD_LIBRARY_SEARCH_USER_DIRS;
 
-/// If `filename specifies an absolute path, the system uses the alternate file search strategy
+/// If `filename` specifies an absolute path, the system uses the alternate file search strategy
 /// discussed in the [Remarks section] to find associated executable modules that the specified
 /// module causes to be loaded.
 ///

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -92,7 +92,7 @@ impl Library {
     ///
     /// # Safety
     ///
-    /// When a library is loaded initialisation routines contained within the library are executed.
+    /// When a library is loaded, initialisation routines contained within the library are executed.
     /// For the purposes of safety, the execution of these routines is conceptually the same calling an
     /// unknown foreign function and may impose arbitrary requirements on the caller for the call
     /// to be sound.
@@ -178,7 +178,7 @@ impl Library {
     ///
     /// # Safety
     ///
-    /// When a library is loaded initialisation routines contained within the library are executed.
+    /// When a library is loaded, initialisation routines contained within the library are executed.
     /// For the purposes of safety, the execution of these routines is conceptually the same calling an
     /// unknown foreign function and may impose arbitrary requirements on the caller for the call
     /// to be sound.

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -452,7 +452,7 @@ pub const LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE: DWORD = consts::LOAD_LIBRARY_AS_DA
 
 /// Map the file into the process’ virtual address space as an image file.
 ///
-/// The loader does not load the static imports or perform the other usual initialization steps.
+/// The loader does not load the static imports or perform the other usual initialisation steps.
 /// Use this flag when you want to load a DLL only to extract messages or resources from it.
 ///
 /// Unless the application depends on the file having the in-memory layout of an image, this value
@@ -513,7 +513,7 @@ pub const LOAD_LIBRARY_SEARCH_USER_DIRS: DWORD = consts::LOAD_LIBRARY_SEARCH_USE
 /// discussed in the [Remarks section] to find associated executable modules that the specified
 /// module causes to be loaded.
 ///
-/// If this value is used and `filename` specifies a relative path, the behavior is undefined.
+/// If this value is used and `filename` specifies a relative path, the behaviour is undefined.
 ///
 /// If this value is not used, or if `filename` does not specify a path, the system uses the
 /// standard search strategy discussed in the [Remarks section] to find associated executable

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,10 +1,10 @@
-use std::ffi::{CStr, CString};
 use std::borrow::Cow;
+use std::ffi::{CStr, CString};
 use std::os::raw;
 
 use crate::Error;
 
-/// Checks for last byte and avoids allocating if it is zero.
+/// Checks for the last byte and avoids allocating if it is zero.
 ///
 /// Non-last null bytes still result in an error.
 pub(crate) fn cstr_cow_from_bytes(slice: &[u8]) -> Result<Cow<'_, CStr>, Error> {
@@ -13,11 +13,14 @@ pub(crate) fn cstr_cow_from_bytes(slice: &[u8]) -> Result<Cow<'_, CStr>, Error> 
         // Slice out of 0 elements
         None => unsafe { Cow::Borrowed(CStr::from_ptr(&ZERO)) },
         // Slice with trailing 0
-        Some(&0) => Cow::Borrowed(CStr::from_bytes_with_nul(slice)
-            .map_err(|source| Error::CreateCStringWithTrailing { source })?),
+        Some(&0) => Cow::Borrowed(
+            CStr::from_bytes_with_nul(slice)
+                .map_err(|source| Error::CreateCStringWithTrailing { source })?,
+        ),
         // Slice with no trailing 0
-        Some(_) => Cow::Owned(CString::new(slice)
-            .map_err(|source| Error::CreateCString { source })?),
+        Some(_) => {
+            Cow::Owned(CString::new(slice).map_err(|source| Error::CreateCString { source })?)
+        }
     })
 }
 

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -148,7 +148,7 @@ fn test_static_ptr() {
 }
 
 #[test]
-// Something about i686-pc-windows-gnu, makes dll initialization code call abort when it is loaded
+// Something about i686-pc-windows-gnu, makes dll initialisation code call abort when it is loaded
 // and unloaded many times. So far it seems like an issue with mingw, not libloading, so ignoring
 // the target. Especially since it is very unlikely to be fixed given the state of support its
 // support.
@@ -193,7 +193,7 @@ fn library_this() {
     use libloading::os::windows::Library;
     make_helpers();
     unsafe {
-        // SAFE: well-known library without initializers is loaded.
+        // SAFE: well-known library without initialisers is loaded.
         let _lib = Library::new(LIBPATH).unwrap();
         let this = Library::this().expect("this library");
         // SAFE: functions are never called.


### PR DESCRIPTION
I've found this library extremely useful in several projects and I'm very grateful for it. I have however found that, as a native English speaker, the documentation does not read particularly clearly in parts and there are some very minor grammatical errors. I have gone through all of the documentation and amended the grammar and phrasing in some places to improve the overall quality of the documentation and I hope this is useful to the project.

I found that there was quite a mix of American and British English spellings in the documentation (for example, "initialise" and "initialize" were used interchangeably). More of the spelling used British English so I chose to change the American spellings into the British ones to make the documentation more consistent. If you would like me to change them all to the American spellings that is equally fine so just let me know.