### PR TITLE
windows: drop dependency on windows-sys

### DIFF
--- a/.github/workflows/libloading.yml
+++ b/.github/workflows/libloading.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_toolchain: [nightly, stable, 1.48.0]
+        rust_toolchain: [nightly, stable, 1.56.0]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     timeout-minutes: 20
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,10 @@ readme = "README.mkd"
 description = "Bindings around the platform's dynamic library loading primitives with greatly improved memory safety."
 keywords = ["dlopen", "load", "shared", "dylib"]
 categories = ["api-bindings"]
-rust-version = "1.48.0"
+rust-version = "1.56.0"
 
-[target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.52"
-features = [
-    "Win32_Foundation",
-    "Win32_System_Diagnostics_Debug",
-    "Win32_System_LibraryLoader",
-]
+[target.'cfg(windows)'.dependencies.windows-targets]
+version = ">=0.48, <0.53"
 
 [target.'cfg(unix)'.dependencies.cfg-if]
 version = "1"
@@ -28,6 +23,7 @@ version = "1"
 [dev-dependencies]
 libc = "0.2"
 static_assertions = "1.1"
+windows-sys = { version = "0.52", features = ["Win32_Foundation"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "libloading"
 # When bumping
 # * Don’t forget to add an entry to `src/changelog.rs`
 # * If bumping to an incompatible version, adjust the documentation in `src/lib.rs`
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Simonas Kazlauskas <libloading@kazlauskas.me>"]
 license = "ISC"
 repository = "https://github.com/nagisa/rust_libloading/"

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,10 +1,27 @@
 //! The change log.
 
+/// Release 0.8.2 (2024-03-01)
+///
+/// ## (Potentially) breaking changes
+///
+/// MSRV has been increased to 1.56.0. Since both rustc versions are ancient, this has been deemed
+/// to not be breaking enough to warrant a semver-breaking release of libloading. If you're stick
+/// with a version of rustc older than 1.56.0, lock `libloading` dependency to `0.8.1`.
+///
+/// ## Non-breaking changes
+///
+/// The crate switches the dependency on `windows-sys` to a `windows-target` one for Windows
+/// bindings. In order to enable this `libloading` defines any bindings necessary for its operation
+/// internally, just like has been done for `unix` targets. This should result in leaner
+/// dependency trees.
+pub mod r0_8_2 {}
+
 /// Release 0.8.1 (2023-09-30)
 ///
 /// ## Non-breaking changes
 ///
 /// * Support for GNU Hurd.
+pub mod r0_8_1 {}
 
 /// Release 0.8.0 (2023-04-11)
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,15 +41,13 @@
 pub mod changelog;
 pub mod os;
 mod util;
-
 mod error;
-pub use self::error::Error;
-
 #[cfg(any(unix, windows, libloading_docs))]
 mod safe;
+
+pub use self::error::Error;
 #[cfg(any(unix, windows, libloading_docs))]
 pub use self::safe::{Library, Symbol};
-
 use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
 use std::ffi::{OsStr, OsString};
 

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -197,7 +197,7 @@ impl Library {
         //
         // We try to leave as little space as possible for this to occur, but we can’t exactly
         // fully prevent it.
-        match with_dlerror(|desc| crate::Error::DlSym { desc }, || {
+        let result = with_dlerror(|desc| crate::Error::DlSym { desc }, || {
             dlerror();
             let symbol = dlsym(self.handle, symbol.as_ptr());
             if symbol.is_null() {
@@ -208,7 +208,8 @@ impl Library {
                     pd: marker::PhantomData
                 })
             }
-        }) {
+        });
+        match result {
             Err(None) => on_null(),
             Err(Some(e)) => Err(e),
             Ok(x) => Ok(x)


### PR DESCRIPTION
This results in a smaller dependency tree for the users and a slightly less maintenance burden for me (I won’t be losing any sleep over outdated dependency now!)

I have chose to make this a patch-point release. I believe this is an entirely compatible release – `LOAD_LIBRARY_FLAGS` is the same typedef to u32 before and after. `HMOODULE` is the same `isize`, etc. The negative is that documentation now displays method types with resolved type names (i.e. `isize` instead of `HMODULE`) which is not great. I would love to make tyese newtypes, but that's gonna need to wait for a breaking change.