### PR TITLE
misc: Update windows-sys dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["api-bindings"]
 rust-version = "1.48.0"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.48"
+version = "0.52"
 features = [
     "Win32_Foundation",
     "Win32_System_Diagnostics_Debug",


### PR DESCRIPTION
It is the only crate that pulls the old version of windows crates

Untested as I don't have access to a windows machine. I saw https://github.com/nagisa/rust_libloading/pull/125 already, but as a short term solution, maybe merging this patch & doing a release would be a good step forward to reduce the amount of windows deps that ends up being pulled by using this crate