### PR TITLE
windows: make windows-sys dev-dependency target-specific

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,16 @@ rust-version = "1.56.0"
 [target.'cfg(windows)'.dependencies.windows-targets]
 version = ">=0.48, <0.53"
 
+[target.'cfg(windows)'.dev-dependencies.windows-sys]
+version = "0.52"
+features = ["Win32_Foundation"]
+
 [target.'cfg(unix)'.dependencies.cfg-if]
 version = "1"
 
 [dev-dependencies]
 libc = "0.2"
 static_assertions = "1.1"
-windows-sys = { version = "0.52", features = ["Win32_Foundation"] }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
The windows-sys dependency is only relevant on cfg(windows) targets.