### PR TITLE
Add `Library::new_with_flags`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ mod safe;
 
 pub use self::error::Error;
 #[cfg(any(unix, windows, libloading_docs))]
-pub use self::safe::{Library, Symbol};
+pub use self::safe::{Library, Symbol, LoadFlags};
 use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
 use std::ffi::{OsStr, OsString};
 


### PR DESCRIPTION
Sometimes it would be convenient to keep the safer lifetime-bound API, but adjust the way the library gets loaded (e.g. to use eager binding). Add `Library::new_with_flags` and a `LoadFlags` type to provide an easier way to do this.