### PR TITLE
Fix minor typos and comment formatting in changelog and test files

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -75,7 +75,7 @@ pub mod r0_8_3 {}
 /// ## (Potentially) breaking changes
 ///
 /// MSRV has been increased to 1.56.0. Since both rustc versions are ancient, this has been deemed
-/// to not be breaking enough to warrant a semver-breaking release of libloading. If you're stick
+/// to not be breaking enough to warrant a semver-breaking release of libloading. If you're stuck
 /// with a version of rustc older than 1.56.0, lock `libloading` dependency to `0.8.1`.
 ///
 /// ## Non-breaking changes

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -17,7 +17,7 @@ fn make_helpers() {
     static ONCE: ::std::sync::Once = ::std::sync::Once::new();
     ONCE.call_once(|| {
         if std::env::var_os("PRECOMPILED_TEST_HELPER").is_some() {
-            //I can't be asked to make rustc work in wine.
+            // I can't be asked to make rustc work in wine.
             //I can call it myself from my linux host and then just move the file here this allows me to skip this.
             eprintln!("WILL NOT COMPILE TEST HELPERS, PROGRAM WILL ASSUME THAT {} EXISTS AND WAS EXTERNALLY PRE COMPILED", lib_path().display());
             return;

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -18,7 +18,7 @@ fn make_helpers() {
     ONCE.call_once(|| {
         if std::env::var_os("PRECOMPILED_TEST_HELPER").is_some() {
             // I can't be asked to make rustc work in wine.
-            //I can call it myself from my linux host and then just move the file here this allows me to skip this.
+            // I can call it myself from my linux host and then just move the file here this allows me to skip this.
             eprintln!("WILL NOT COMPILE TEST HELPERS, PROGRAM WILL ASSUME THAT {} EXISTS AND WAS EXTERNALLY PRE COMPILED", lib_path().display());
             return;
         }


### PR DESCRIPTION

This commit corrects a typo in `src/changelog.rs` where "If you're stick" was changed to "If you're stuck" and improves comment formatting in `tests/functions.rs` by adding proper spacing after comment markers. 

These are minor documentation improvements that enhance readability without changing any functional code.