### PR TITLE
Don't link with libdl on musl

### DIFF
--- a/.github/workflows/libloading.yml
+++ b/.github/workflows/libloading.yml
@@ -48,6 +48,16 @@ jobs:
       - name: Compile without the standard library
         run: cargo clean && cargo +nightly build -Zbuild-std=core,alloc --no-default-features
 
+  musl-rust-lld-link-test:
+    runs-on: ubuntu-latest
+    # This test checks if binaries using libloading can be linked using rust-lld linker for target environments that
+    # provide a unified libc (e.g. musl) without needing to provide additional library paths to the linker.
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup install stable --profile=minimal
+      - run: rustup target add x86_64-unknown-linux-musl
+      - run: RUSTFLAGS="-Clinker=rust-lld" cargo build --target=x86_64-unknown-linux-musl --example e1
+
   windows-test:
     runs-on: windows-latest
     strategy:

--- a/examples/e1.rs
+++ b/examples/e1.rs
@@ -1,0 +1,5 @@
+fn main() {
+    unsafe {
+        libloading::Library::new("libc.so").unwrap();
+    }
+}

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -479,7 +479,14 @@ impl<T> fmt::Debug for Symbol<T> {
 }
 
 // Platform specific things
-#[cfg_attr(any(target_os = "linux", target_os = "android"), link(name = "dl"))]
+#[cfg_attr(
+    any(
+        all(target_os = "linux", not(target_env = "musl")),
+        target_os = "android"
+    ),
+    link(name = "dl")
+)]
+#[cfg_attr(all(target_os = "linux", target_env = "musl"), link(name = "c"))]
 #[cfg_attr(any(target_os = "freebsd", target_os = "dragonfly"), link(name = "c"))]
 extern "C" {
     fn dlopen(


### PR DESCRIPTION
On musl dlopen is part of libc and there's no separate libdl.

I 'm using cryptoki crate, which uses libloading, and using cargo-zigbuild to compile for `x86_64-unknown-linux-musl`.
Without the change, I get the following error:

```
export 'CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS=-Clink-self-contained=yes -Clinker=rust-lld'
+ CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS='-Clink-self-contained=yes -Clinker=rust-lld'
+ MUSL_SYSROOT_DIR=/home/runner/.musl-cross/x86_64-unknown-linux-musl/x86_64-unknown-linux-musl/sysroot
+ export CFLAGS_x86_64_unknown_linux_musl=--sysroot=/home/runner/.musl-cross/x86_64-unknown-linux-musl/x86_64-unknown-linux-musl/sysroot
+ CFLAGS_x86_64_unknown_linux_musl=--sysroot=/home/runner/.musl-cross/x86_64-unknown-linux-musl/x86_64-unknown-linux-musl/sysroot
+ export BINDGEN_EXTRA_CLANG_ARGS=--sysroot=/home/runner/.musl-cross/x86_64-unknown-linux-musl/x86_64-unknown-linux-musl/sysroot
+ BINDGEN_EXTRA_CLANG_ARGS=--sysroot=/home/runner/.musl-cross/x86_64-unknown-linux-musl/x86_64-unknown-linux-musl/sysroot
+ target_lower=x86_64_unknown_linux_musl
+ '[' -n '' ']'
+ '[' -n 1 ']'
+ cc_var=CC_x86_64_unknown_linux_musl
+ declare -x CC_x86_64_unknown_linux_musl=clang-20
+ ar_var=AR_x86_64_unknown_linux_musl
+ declare -x AR_x86_64_unknown_linux_musl=llvm-ar-20
+ cargo +1.85 build --target=x86_64-unknown-linux-musl --release --bin tedge

...

error: linking with `rust-lld` failed: exit status: 1
  |
  = note: LC_ALL="C" PATH="/home/runner/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin:/home/runner/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/self-contained:/home/runner/go/bin:/opt/hostedtoolcache/go/1.25.7/x64/bin:/snap/bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin" VSLANG="1033" "rust-lld" "-flavor" "gnu" "/home/runner/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-musl/lib/self-contained/rcrt1.o" "/home/runner/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-musl/lib/self-contained/crti.o" "/home/runner/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-musl/lib/self-contained/crtbeginS.o" "/tmp/rustcGufnkP/symbols.o" "<1 object files omitted>" "--as-needed" "-Bstatic" "/tmp/rustcGufnkP/{libpsm-cc7b4c60c1da627b.rlib,librquickjs_sys-49b63039f738dd1d.rlib}" "-ldl" "/tmp/rustcGufnkP/{libring-663d3b1d300a9115.rlib}" "-lunwind" "-lc" "/home/runner/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-musl/lib/{libcompiler_builtins-40918110fa23a9da.rlib}" "-Bdynamic" "--eh-frame-hdr" "-z" "noexecstack" "-L" "/home/runner/work/thin-edge.io/thin-edge.io/target/x86_64-unknown-linux-musl/release/build/ring-ef496e57d4f79bce/out" "-L" "/home/runner/work/thin-edge.io/thin-edge.io/target/x86_64-unknown-linux-musl/release/build/rquickjs-sys-5b5d11e0c34c9d4c/out" "-L" "/home/runner/work/thin-edge.io/thin-edge.io/target/x86_64-unknown-linux-musl/release/build/psm-3eb4793e05b003f8/out" "-L" "/home/runner/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-musl/lib/self-contained" "-L" "/home/runner/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-musl/lib" "-o" "/home/runner/work/thin-edge.io/thin-edge.io/target/x86_64-unknown-linux-musl/release/deps/tedge-033e35ff27f7f158" "--gc-sections" "-static" "-pie" "--no-dynamic-linker" "-z" "text" "-z" "relro" "-z" "now" "--strip-all" "/home/runner/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-musl/lib/self-contained/crtendS.o" "/home/runner/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-musl/lib/self-contained/crtn.o"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: rust-lld: error: unable to find library -ldl
          

error: could not compile `tedge` (bin "tedge") due to 1 previous error
error: Recipe `release` failed on line 131 with exit code 101
Error: Process completed with exit code 101.
```