### PR TITLE
use `&raw mut` instead of casting `&mut` to raw pointer

### DIFF
--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -33,7 +33,7 @@ pub unsafe extern "C" fn test_get_static_u32() -> u32 {
 
 #[no_mangle]
 pub unsafe extern "C" fn test_check_static_ptr() -> bool {
-    TEST_STATIC_PTR == (&mut TEST_STATIC_PTR as *mut *mut _ as *mut _)
+    TEST_STATIC_PTR == &raw mut TEST_STATIC_PTR as *mut _
 }
 
 #[unsafe(no_mangle)]


### PR DESCRIPTION
This gets rid of:
```text
warning: creating a mutable reference to mutable static
  --> src/test_helpers.rs:36:25
   |
36 |     TEST_STATIC_PTR == (&mut TEST_STATIC_PTR as *mut *mut _ as *mut _)
   |                         ^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
   |
   = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
   = note: `#[warn(static_mut_refs)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
help: use `&raw mut` instead to create a raw pointer
   |
36 |     TEST_STATIC_PTR == (&raw mut TEST_STATIC_PTR as *mut *mut _ as *mut _)
```