### PR TITLE
replace manual Vec::with_capacity

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -26,10 +26,8 @@ pub(crate) fn check_null_bytes(data: &[u8]) -> Result<bool, Error> {
 }
 
 /// This function copies the slice into a vec and appends an element to its end.
-/// The vec is allocated with reserve_exact.
 pub(crate) fn copy_and_push<T: Copy>(data: &[T], to_push: T) -> alloc::vec::Vec<T> {
-    let mut copy = alloc::vec::Vec::new();
-    copy.reserve_exact(data.len() + 1);
+    let mut copy = alloc::vec::Vec::with_capacity(data.len() + 1);
     copy.extend_from_slice(data);
     copy.push(to_push);
     copy


### PR DESCRIPTION
Vec::with_capacity provides the same guarantee since https://github.com/rust-lang/rust/pull/135933.

I removed the comment that would otherwise be a lie, and I would say this function behaves as would expected for idiomatic Rust, so no comment seems necessary. But perhaps you still want to be explicit here? In that case, should it say that it uses `Vec::with_capacity` or should it say something about the guarantee that that function provides?