### PR TITLE
use std const assertions instead of crate static_assertions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ version = "1"
 
 [dev-dependencies]
 libc = "0.2"
-static_assertions = "1.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tests/constants.rs
+++ b/tests/constants.rs
@@ -1,9 +1,7 @@
 #[cfg(all(test, unix))]
 mod unix {
-    use static_assertions::const_assert_eq;
-
-    const_assert_eq!(libloading::os::unix::RTLD_LOCAL, libc::RTLD_LOCAL);
-    const_assert_eq!(libloading::os::unix::RTLD_GLOBAL, libc::RTLD_GLOBAL);
-    const_assert_eq!(libloading::os::unix::RTLD_NOW, libc::RTLD_NOW);
-    const_assert_eq!(libloading::os::unix::RTLD_LAZY, libc::RTLD_LAZY);
+    const _: () = assert!(libloading::os::unix::RTLD_LOCAL == libc::RTLD_LOCAL);
+    const _: () = assert!(libloading::os::unix::RTLD_GLOBAL == libc::RTLD_GLOBAL);
+    const _: () = assert!(libloading::os::unix::RTLD_NOW == libc::RTLD_NOW);
+    const _: () = assert!(libloading::os::unix::RTLD_LAZY == libc::RTLD_LAZY);
 }


### PR DESCRIPTION
The std alternative is just as good as what the crate achieves, and fewer dependencies means less supply chain risk.